### PR TITLE
Added new mtl file when generating obj file

### DIFF
--- a/src/Husky/Husky/Games/AdvancedWarfare.cs
+++ b/src/Husky/Husky/Games/AdvancedWarfare.cs
@@ -22,6 +22,8 @@ using System.IO;
 using SELib;
 using SELib.Utilities;
 using System.Diagnostics;
+// ApexModder: 16/11/18 - Added to use List<> type
+using System.Collections.Generic;
 
 namespace Husky
 {
@@ -95,9 +97,18 @@ namespace Husky
                     // Create Dir
                     Directory.CreateDirectory(Path.GetDirectoryName(gfxMapName));
 
+                    // ApexModder: 16/11/18 - Store materials
+                    var materialNames = new List<String>();
+
+                    // ApexModder: 16/11/18 - Store obj path as its used more than once
+                    var mtlFilePath = Path.ChangeExtension(gfxMapName, ".mtl");
+
                     // Create OBJ output
                     using (StreamWriter writer = new StreamWriter(Path.ChangeExtension(gfxMapName, ".obj")))
                     {
+                        // ApexModder: 16/11/18 - Reference the .MTL file we generate below
+                        writer.WriteLine("mtllib {0}", Path.GetFileName(mtlFilePath)); // mtllib <mapname>.mtl
+
                         // Dump vertex data
                         foreach (var vertex in vertices)
                         {
@@ -111,6 +122,10 @@ namespace Husky
                         {
                             // Get Material Name
                             var materialName = Path.GetFileNameWithoutExtension(reader.ReadNullTerminatedString(reader.ReadInt64(surface.MaterialPointer)).Replace("*", ""));
+
+                            // ApexModder: 16/11/18 - Store if not already in array
+                            if (!materialNames.Contains(materialName))
+                                materialNames.Add(materialName);
 
                             // Write MTL and Group
                             writer.WriteLine("g {0}", materialName);
@@ -131,6 +146,21 @@ namespace Husky
                                         faceIndex3,
                                         faceIndex2);
                             }
+                        }
+                    }
+
+                    // ApexModder: 16/11/18 - Write a .MTL file for the .OBJ file
+                    using (StreamWriter mtlWriter = new StreamWriter(mtlFilePath))
+                    {
+                        foreach (var materialName in materialNames)
+                        {
+                            mtlWriter.WriteLine("newmtl {0}", materialName);
+                            // ApexModder: 16/11/18 - flatwhite material
+                            mtlWriter.WriteLine("Ka 0.5000 0.5000 0.5000");
+                            mtlWriter.WriteLine("Kd 1.0000 1.0000 1.0000");
+                            mtlWriter.WriteLine("illum 1");
+                            // ApexModder: 16/11/18 - seperate each material def with blank line
+                            mtlWriter.WriteLine();
                         }
                     }
 

--- a/src/Husky/Husky/Games/Ghosts.cs
+++ b/src/Husky/Husky/Games/Ghosts.cs
@@ -22,6 +22,8 @@ using System.IO;
 using SELib;
 using SELib.Utilities;
 using System.Diagnostics;
+// ApexModder: 16/11/18 - Added to use List<> type
+using System.Collections.Generic;
 
 namespace Husky
 {
@@ -95,9 +97,18 @@ namespace Husky
                     // Create Dir
                     Directory.CreateDirectory(Path.GetDirectoryName(gfxMapName));
 
+                    // ApexModder: 16/11/18 - Store materials
+                    var materialNames = new List<String>();
+
+                    // ApexModder: 16/11/18 - Store obj path as its used more than once
+                    var mtlFilePath = Path.ChangeExtension(gfxMapName, ".mtl");
+
                     // Create OBJ output
                     using (StreamWriter writer = new StreamWriter(Path.ChangeExtension(gfxMapName, ".obj")))
                     {
+                        // ApexModder: 16/11/18 - Reference the .MTL file we generate below
+                        writer.WriteLine("mtllib {0}", Path.GetFileName(mtlFilePath)); // mtllib <mapname>.mtl
+
                         // Dump vertex data
                         foreach (var vertex in vertices)
                         {
@@ -111,6 +122,10 @@ namespace Husky
                         {
                             // Get Material Name, purge any prefixes and Auto-Gen star characters
                             var materialName = Path.GetFileNameWithoutExtension(reader.ReadNullTerminatedString(reader.ReadInt64(surface.MaterialPointer)).Replace("*", ""));
+
+                            // ApexModder: 16/11/18 - Store if not already in array
+                            if (!materialNames.Contains(materialName))
+                                materialNames.Add(materialName);
 
                             // Write MTL and Group
                             writer.WriteLine("g {0}", materialName);
@@ -130,6 +145,21 @@ namespace Husky
                                         faceIndex3,
                                         faceIndex2);
                             }
+                        }
+                    }
+
+                    // ApexModder: 16/11/18 - Write a .MTL file for the .OBJ file
+                    using (StreamWriter mtlWriter = new StreamWriter(mtlFilePath))
+                    {
+                        foreach (var materialName in materialNames)
+                        {
+                            mtlWriter.WriteLine("newmtl {0}", materialName);
+                            // ApexModder: 16/11/18 - flatwhite material
+                            mtlWriter.WriteLine("Ka 0.5000 0.5000 0.5000");
+                            mtlWriter.WriteLine("Kd 1.0000 1.0000 1.0000");
+                            mtlWriter.WriteLine("illum 1");
+                            // ApexModder: 16/11/18 - seperate each material def with blank line
+                            mtlWriter.WriteLine();
                         }
                     }
 

--- a/src/Husky/Husky/Games/ModernWarfare2.cs
+++ b/src/Husky/Husky/Games/ModernWarfare2.cs
@@ -22,6 +22,8 @@ using System.IO;
 using SELib;
 using SELib.Utilities;
 using System.Diagnostics;
+// ApexModder: 16/11/18 - Added to use List<> type
+using System.Collections.Generic;
 
 namespace Husky
 {
@@ -94,9 +96,18 @@ namespace Husky
                     // Create Dir
                     Directory.CreateDirectory(Path.GetDirectoryName(gfxMapName));
 
+                    // ApexModder: 16/11/18 - Store materials
+                    var materialNames = new List<String>();
+
+                    // ApexModder: 16/11/18 - Store obj path as its used more than once
+                    var mtlFilePath = Path.ChangeExtension(gfxMapName, ".mtl");
+
                     // Create OBJ output
                     using (StreamWriter writer = new StreamWriter(Path.ChangeExtension(gfxMapName, ".obj")))
                     {
+                        // ApexModder: 16/11/18 - Reference the .MTL file we generate below
+                        writer.WriteLine("mtllib {0}", Path.GetFileName(mtlFilePath)); // mtllib <mapname>.mtl
+
                         // Dump vertex data
                         foreach (var vertex in vertices)
                         {
@@ -110,6 +121,10 @@ namespace Husky
                         {
                             // Get Material Name, purge any prefixes and Auto-Gen star characters
                             var materialName = Path.GetFileNameWithoutExtension(reader.ReadNullTerminatedString(reader.ReadInt32(surface.MaterialPointer)).Replace("*", ""));
+
+                            // ApexModder: 16/11/18 - Store if not already in array
+                            if (!materialNames.Contains(materialName))
+                                materialNames.Add(materialName);
 
                             // Write MTL and Group
                             writer.WriteLine("g {0}", materialName);
@@ -129,6 +144,21 @@ namespace Husky
                                         faceIndex3,
                                         faceIndex2);
                             }
+                        }
+                    }
+
+                    // ApexModder: 16/11/18 - Write a .MTL file for the .OBJ file
+                    using (StreamWriter mtlWriter = new StreamWriter(mtlFilePath))
+                    {
+                        foreach (var materialName in materialNames)
+                        {
+                            mtlWriter.WriteLine("newmtl {0}", materialName);
+                            // ApexModder: 16/11/18 - flatwhite material
+                            mtlWriter.WriteLine("Ka 0.5000 0.5000 0.5000");
+                            mtlWriter.WriteLine("Kd 1.0000 1.0000 1.0000");
+                            mtlWriter.WriteLine("illum 1");
+                            // ApexModder: 16/11/18 - seperate each material def with blank line
+                            mtlWriter.WriteLine();
                         }
                     }
 

--- a/src/Husky/Husky/Games/ModernWarfare3.cs
+++ b/src/Husky/Husky/Games/ModernWarfare3.cs
@@ -22,6 +22,8 @@ using System.IO;
 using SELib;
 using SELib.Utilities;
 using System.Diagnostics;
+// ApexModder: 16/11/18 - Added to use List<> type
+using System.Collections.Generic;
 
 namespace Husky
 {
@@ -94,9 +96,18 @@ namespace Husky
                     // Create Dir
                     Directory.CreateDirectory(Path.GetDirectoryName(gfxMapName));
 
+                    // ApexModder: 16/11/18 - Store materials
+                    var materialNames = new List<String>();
+
+                    // ApexModder: 16/11/18 - Store obj path as its used more than once
+                    var mtlFilePath = Path.ChangeExtension(gfxMapName, ".mtl");
+
                     // Create OBJ output
                     using (StreamWriter writer = new StreamWriter(Path.ChangeExtension(gfxMapName, ".obj")))
                     {
+                        // ApexModder: 16/11/18 - Reference the .MTL file we generate below
+                        writer.WriteLine("mtllib {0}", Path.GetFileName(mtlFilePath)); // mtllib <mapname>.mtl
+
                         // Dump vertex data
                         foreach (var vertex in vertices)
                         {
@@ -110,6 +121,10 @@ namespace Husky
                         {
                             // Get Material Name, purge any prefixes and Auto-Gen star characters
                             var materialName = Path.GetFileNameWithoutExtension(reader.ReadNullTerminatedString(reader.ReadInt32(surface.MaterialPointer)).Replace("*", ""));
+
+                            // ApexModder: 16/11/18 - Store if not already in array
+                            if (!materialNames.Contains(materialName))
+                                materialNames.Add(materialName);
 
                             // Write MTL and Group
                             writer.WriteLine("g {0}", materialName);
@@ -131,6 +146,21 @@ namespace Husky
                                         faceIndex3,
                                         faceIndex2);
                             }
+                        }
+                    }
+
+                    // ApexModder: 16/11/18 - Write a .MTL file for the .OBJ file
+                    using (StreamWriter mtlWriter = new StreamWriter(mtlFilePath))
+                    {
+                        foreach (var materialName in materialNames)
+                        {
+                            mtlWriter.WriteLine("newmtl {0}", materialName);
+                            // ApexModder: 16/11/18 - flatwhite material
+                            mtlWriter.WriteLine("Ka 0.5000 0.5000 0.5000");
+                            mtlWriter.WriteLine("Kd 1.0000 1.0000 1.0000");
+                            mtlWriter.WriteLine("illum 1");
+                            // ApexModder: 16/11/18 - seperate each material def with blank line
+                            mtlWriter.WriteLine();
                         }
                     }
 

--- a/src/Husky/Husky/Games/ModernWarfareRM.cs
+++ b/src/Husky/Husky/Games/ModernWarfareRM.cs
@@ -22,6 +22,8 @@ using System.IO;
 using SELib;
 using SELib.Utilities;
 using System.Diagnostics;
+// ApexModder: 16/11/18 - Added to use List<> type
+using System.Collections.Generic;
 
 namespace Husky
 {
@@ -95,9 +97,18 @@ namespace Husky
                     // Create Dir
                     Directory.CreateDirectory(Path.GetDirectoryName(gfxMapName));
 
+                    // ApexModder: 16/11/18 - Store materials
+                    var materialNames = new List<String>();
+
+                    // ApexModder: 16/11/18 - Store obj path as its used more than once
+                    var mtlFilePath = Path.ChangeExtension(gfxMapName, ".mtl");
+
                     // Create OBJ output
                     using (StreamWriter writer = new StreamWriter(Path.ChangeExtension(gfxMapName, ".obj")))
                     {
+                        // ApexModder: 16/11/18 - Reference the .MTL file we generate below
+                        writer.WriteLine("mtllib {0}", Path.GetFileName(mtlFilePath)); // mtllib <mapname>.mtl
+
                         // Dump vertex data
                         foreach (var vertex in vertices)
                         {
@@ -111,6 +122,10 @@ namespace Husky
                         {
                             // Get Material Name
                             var materialName = Path.GetFileNameWithoutExtension(reader.ReadNullTerminatedString(reader.ReadInt64(surface.MaterialPointer)).Replace("*", ""));
+
+                            // ApexModder: 16/11/18 - Store if not already in array
+                            if (!materialNames.Contains(materialName))
+                                materialNames.Add(materialName);
 
                             // Write MTL and Group
                             writer.WriteLine("g {0}", materialName);
@@ -131,6 +146,21 @@ namespace Husky
                                         faceIndex3,
                                         faceIndex2);
                             }
+                        }
+                    }
+
+                    // ApexModder: 16/11/18 - Write a .MTL file for the .OBJ file
+                    using (StreamWriter mtlWriter = new StreamWriter(mtlFilePath))
+                    {
+                        foreach (var materialName in materialNames)
+                        {
+                            mtlWriter.WriteLine("newmtl {0}", materialName);
+                            // ApexModder: 16/11/18 - flatwhite material
+                            mtlWriter.WriteLine("Ka 0.5000 0.5000 0.5000");
+                            mtlWriter.WriteLine("Kd 1.0000 1.0000 1.0000");
+                            mtlWriter.WriteLine("illum 1");
+                            // ApexModder: 16/11/18 - seperate each material def with blank line
+                            mtlWriter.WriteLine();
                         }
                     }
 

--- a/src/Husky/Husky/Games/WorldAtWar.cs
+++ b/src/Husky/Husky/Games/WorldAtWar.cs
@@ -22,6 +22,8 @@ using System.IO;
 using SELib;
 using SELib.Utilities;
 using System.Diagnostics;
+// ApexModder: 16/11/18 - Added to use List<> type
+using System.Collections.Generic;
 
 namespace Husky
 {
@@ -98,9 +100,18 @@ namespace Husky
                     // Create Dir
                     Directory.CreateDirectory(Path.GetDirectoryName(gfxMapName));
 
+                    // ApexModder: 16/11/18 - Store materials
+                    var materialNames = new List<String>();
+
+                    // ApexModder: 16/11/18 - Store obj path as its used more than once
+                    var mtlFilePath = Path.ChangeExtension(gfxMapName, ".mtl");
+
                     // Create OBJ output
                     using (StreamWriter writer = new StreamWriter(Path.ChangeExtension(gfxMapName, ".obj")))
                     {
+                        // ApexModder: 16/11/18 - Reference the .MTL file we generate below
+                        writer.WriteLine("mtllib {0}", Path.GetFileName(mtlFilePath)); // mtllib <mapname>.mtl
+
                         // Dump vertex data
                         foreach (var vertex in vertices)
                         {
@@ -114,6 +125,10 @@ namespace Husky
                         {
                             // Get Material Name, purge any prefixes and Auto-Gen star characters
                             var materialName = Path.GetFileNameWithoutExtension(reader.ReadNullTerminatedString(reader.ReadInt32(surface.MaterialPointer)).Replace("*", ""));
+
+                            // ApexModder: 16/11/18 - Store if not already in array
+                            if (!materialNames.Contains(materialName))
+                                materialNames.Add(materialName);
 
                             // Write MTL and Group
                             writer.WriteLine("g {0}", materialName);
@@ -133,6 +148,21 @@ namespace Husky
                                         faceIndex3,
                                         faceIndex2);
                             }
+                        }
+                    }
+
+                    // ApexModder: 16/11/18 - Write a .MTL file for the .OBJ file
+                    using (StreamWriter mtlWriter = new StreamWriter(mtlFilePath))
+                    {
+                        foreach (var materialName in materialNames)
+                        {
+                            mtlWriter.WriteLine("newmtl {0}", materialName);
+                            // ApexModder: 16/11/18 - flatwhite material
+                            mtlWriter.WriteLine("Ka 0.5000 0.5000 0.5000");
+                            mtlWriter.WriteLine("Kd 1.0000 1.0000 1.0000");
+                            mtlWriter.WriteLine("illum 1");
+                            // ApexModder: 16/11/18 - seperate each material def with blank line
+                            mtlWriter.WriteLine();
                         }
                     }
 


### PR DESCRIPTION
When importing the OBJ model into Maya it was not loading in any materials. Quick look around in the OBJ file and I noticed that the mesh's are named the same as the materials they use. This change just generates a extra file which creates material entries when the OBJ is imported.

Only missing from these map dumps now is collision, if we somehow get, remasters be crazy accurate.

**Preview of generated materials in Maya**
_Note: Some are colored to show they are actually bound to a mesh_
![Preview](https://i.imgur.com/8UtlRFM.png)

[**Original**](https://paste.md-5.net/yucaxarili.js) - Started of as some shitty JS script