### PR TITLE
COD4 1.8 offset + obj format fix

### DIFF
--- a/src/Husky/Husky/HuskyUtil.cs
+++ b/src/Husky/Husky/HuskyUtil.cs
@@ -41,8 +41,8 @@ namespace Husky
             { "CoDWaWmp",           new GameDefinition(0x8D0958,          0x8D06E8,       "mp",               WorldatWar.ExportBSPData) },
             { "CoDWaW",             new GameDefinition(0x8DC828,          0x8DC5D0,       "sp",               WorldatWar.ExportBSPData) },
             // Call of Duty: Modern Warfare
-            { "iw3mp",              new GameDefinition(0x7265E0,          0x7263A0,       "mp",               ModernWarfare.ExportBSPData) },
-            { "iw3sp",              new GameDefinition(0x7307F8,          0x730510,       "sp",               ModernWarfare.ExportBSPData) },
+            { "iw3mp",              new GameDefinition(0x71E5D8,          0x7263A0,       "mp",               ModernWarfare.ExportBSPData) },
+            { "iw3sp",              new GameDefinition(0x6DF200,          0x730510,       "sp",               ModernWarfare.ExportBSPData) },
             // Call of Duty: Modern Warfare 2
             { "iw4mp",              new GameDefinition(0x6F81D0,          0x6F7F08,       "mp",               ModernWarfare2.ExportBSPData) },
             { "iw4sp",              new GameDefinition(0x7307F8,          0x730510,       "sp",               ModernWarfare2.ExportBSPData) },

--- a/src/Husky/HuskyUI/MainWindow.xaml.cs
+++ b/src/Husky/HuskyUI/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using System.Windows.Shell;
 using Husky;
 using System.Reflection;
+using System.Globalization;
 
 namespace HuskyUI
 {
@@ -45,6 +46,9 @@ namespace HuskyUI
             // Initial Print
             PrintLine("Load a supported CoD Game, then click the paper plane to export loaded BSP data.");
             PrintLine("");
+
+            // Reset culture for OBJs.
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
         }
 
         private void ExportClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Updated the addresses for iw3mp and iw3sp for the 1.8 Patch.
Added a line to set culture to InvariantCulture to force Husky to write comma separators, independent from the user's locale.