### PR TITLE
Bug Fix to ensure compatibility with old CD based versions of the games

### DIFF
--- a/src/Husky/Husky/HuskyUtil.cs
+++ b/src/Husky/Husky/HuskyUtil.cs
@@ -35,7 +35,7 @@ namespace Husky
         /// <summary>
         /// Game Addresses & Methods (Asset DB and Asset Pool Sizes) (Some are relative due to ASLR)
         /// </summary>
-        static Dictionary<string, GameDefinition> Games = new Dictionary<string, GameDefinition>()
+        static Dictionary<string, GameDefinition> Games = new Dictionary<string, GameDefinition>(StringComparer.OrdinalIgnoreCase)
         {
             // Call of Duty: World At War
             { "CoDWaWmp",           new GameDefinition(0x8D0958,          0x8D06E8,       "mp",               WorldatWar.ExportBSPData) },


### PR DESCRIPTION
this fix simply makes the Game Keys in the Games Dictionary non case sensitive.

Older, CD based versions of the games may have used different casing for executable names (for example codwaw.exe instead of CoDWaW.exe) causing the game check to fail incorrectly.